### PR TITLE
扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤 (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,206 @@ CompareBuilder，如图所示
 
 + 用户登出后使用cleanRbacKey清空key的session值
 
+## 权限过滤机制
+不同用户一般只能看到与自己相关的数据，该机制可以限制后台用户访问数据的权限，不用针对不同用户分别处理where表达式，降低开发难度。
+
+#### 用法
++ 用户登录成功后设置AUTH_RULE_ID的session值；
+
++ 配置对应Model类的$_auth_ref_rule
+
+如某机构（全思小伙伴）只能查看其创建书库点的书箱，则：
+```php
+    // auth_ref_key是与用户关联的字段，即AUTH_RULE_ID的值
+    // ref_path是该字段有关的数据表及其对应字段
+    
+    // 机构OrganizationModel的配置
+    protected $_auth_ref_rule = array(
+        'auth_ref_key' => 'id',
+        'ref_path' => 'Organization.id'
+    );
+    
+    // 书库点LibraryModel的配置
+    protected $_auth_ref_rule = array(
+        'auth_ref_key' => 'org_id',
+        'ref_path' => 'Organization.id'
+    );
+    
+    // 书库点BoxModel的配置
+    protected $_auth_ref_rule = array(
+        'auth_ref_key' => 'library_id',
+        'ref_path' => 'Library.id'
+    );
+```
+
+若不使用该机制，则需要根据登录用户来处理where表达式，会导致查询的层级越高，代码量就越多：
+```php
+    // 不使用该机制，机构查询书箱数据，则需要根据登录用户获取org_id，再根据org_id获取library_id，再根据library_id获取书箱id，最后根据书箱id找出书箱数据：
+    if (session('?USER_AUTH_KEY')){
+        $org_id = D('OrganizationUser')->where(['id' => session('USER_AUTH_KEY')])->getField('org_id');
+        !$org_id && $org_map['_string'] = "1=0";
+        $org_id && $library_ids = D('Library')->where(['org_id' => $org_id])->getField('id', true);
+        if ($library_ids){
+            $box_ids = D('Box')->where(['library_id'=>['IN',$library_ids]]) -> getField('id',true);
+            $box_ids && $org_map['id'] = ['IN', $box_ids];
+            !$box_ids && $org_map['_string'] = "1=0";
+        }else{
+            $org_map['_string'] = "1=0";
+        }
+        $org_map && $map = array_merge($map, $org_map);
+    }
+    D('Box')->where($map)->select();
+    
+```
+
+使用该机制后，机构查询书箱数据：
+```php
+    D('Box')->where($map)->select();
+```
+
+## 扩展权限过滤机制
+如系统存在机构用户OrgUser与书库点管理员LibraryUser，有书库点Library数据分别与他们关联（org_id与id）时，对应的LibraryModel应该这样配置：
+```php
+// 对于OrgUser，书库点LibraryModel的配置
+protected $_auth_ref_rule = array(
+    'auth_ref_key' => 'org_id',
+    'ref_path' => 'Organization.id'
+);
+
+// 对于LibraryUser，书库点LibraryModel的配置
+protected $_auth_ref_rule = array(
+    'auth_ref_key' => 'id',
+    'ref_path' => 'Library.id'
+);
+```
+
+显然之前的权限过滤机制不能满足需求。
+
+当系统存在多种不同类型的用户，而这些用户与数据相关联的字段不一致，扩展后可以根据不同类型的用户配置不同的权限过滤。
+
+#### 用法
++ 配置对应Model类的$_auth_ref_rule，自定义不同用户类型的权限过滤
+
+```php
+    // 机构OrganizationModel的配置
+    protected $_auth_ref_rule = array(
+        'auth_ref_key' => 'id',
+        'ref_path' => 'Organization.id'
+    );
+    
+    // 用户类型org为机构
+    // 用户类型library为书库点管理员
+
+    // 书库点LibraryModel的配置
+    protected $_auth_ref_rule = array(
+        'org' => [
+            'auth_ref_key' => 'org_id',
+            'ref_path' => 'Organization.id'
+        ],
+        'library' => [
+            'auth_ref_key' => 'id',
+            'ref_path' => 'Library.id'
+        ]
+    );
+```
+
++ 登录方法需先清空再设置“AUTH_RULE_ID”、“AUTH_ROLE_TYPE”对应的值
+
+```php
+
+    // 用户类型为“library”的登录方法
+    public function libraryUserLogin($name,$pwd){
+        // 省略登录逻辑处理
+        ……
+        ……
+        ……
+
+        // 登录成功后
+        if ($r !== false){
+            cleanRbacKey();
+                   
+            session('LIBRARY_USER_LOGIN_ID',$ent['id']);            
+            session(C('USER_AUTH_KEY'), $ent['id']);
+            
+            \Qscmf\Core\AuthChain::setAuthFilterKey($ent['library_id'], 'library');
+
+            session('ADMIN_LOGIN', true);
+            session('HOME_LOGIN', null);
+            sysLogs('书库点管理员后台登录');
+
+            return true;
+        }else{
+            return false;
+        }
+    }
+    
+    // 用户类型为“org”的登录方法
+    public function adminLogin($user_name, $pwd){
+        // 省略登录逻辑处理
+        ……
+        ……
+        ……
+        
+        // 登录成功后            
+        if (!$ent){
+            return false;
+        }             
+        cleanRbacKey();
+
+        // 设置超级管理员权限
+        if ($ent['id'] == C('USER_AUTH_ADMINID')) {
+            session(C('ADMIN_AUTH_KEY'), true);
+        } else {
+            session(C('ADMIN_AUTH_KEY'), false);
+        }        
+        
+        session('ORG_USER_LOGIN_ID', $ent['id']);      
+        session(C('USER_AUTH_KEY'), $ent['id']);
+        
+        \Qscmf\Core\AuthChain::setAuthFilterKey($ent['company_id'], 'org');
+        
+        session('ADMIN_LOGIN', true);
+        session('HOME_LOGIN', null);
+        sysLogs($ent['company_id'] ? '机构后台登录' : '平台用户后台登录');
+
+        return true;
+    }
+    
+```
++ 登出方法需要使用函数“cleanRbacKey”、“cleanAuthFilterKey”清空对应的值
+
+```php
+    // 用户类型为“org”的登出方法
+    public function sso_out(){
+        if (isAdminLogin()) {
+            cleanRbacKey();
+            
+            \Qscmf\Core\AuthChain::cleanAuthFilterKey();
+
+            session(C('ADMIN_AUTH_KEY'), null);
+            session(C('USER_AUTH_KEY'), null);
+            session('ADMIN_LOGIN', null);
+            sysLogs('后台登出');
+        }
+    }
+    
+    // 用户类型为“library”的登出方法
+    public function libraryUserLogout(){
+        if (isAdminLogin()) {
+            cleanRbacKey();
+            
+            \Qscmf\Core\AuthChain::cleanAuthFilterKey();
+
+            session(C('ADMIN_AUTH_KEY'), null);
+            session(C('USER_AUTH_KEY'), null);
+            session('ADMIN_LOGIN', null);
+            sysLogs('后台登出');
+        }
+        
+        $this->redirect('Public/libraryUserLogin');
+    }
+```
+
 ## 工具类
 
 #### RedisLock类：基于Redis改造的悲观锁

--- a/app/Admin/Controller/PublicController.class.php
+++ b/app/Admin/Controller/PublicController.class.php
@@ -67,12 +67,13 @@ class PublicController extends Controller {
     public function logout() {
         if (isAdminLogin()) {
             cleanRbacKey();
+            \Qscmf\Core\AuthChain::cleanAuthFilterKey();
 
-            sysLogs('后台登出');
             session(C('ADMIN_AUTH_KEY'), null);
             session(C('USER_AUTH_KEY'), null);
             session('ADMIN_LOGIN', null);
-        } 
+            sysLogs('后台登出');
+        }
         $this->redirect('Public/login');
     }
 


### PR DESCRIPTION
* readme更新ueditor组件与RedisLock类注释

* top_menu的url使用U函数处理

* xh

* 扩展excel可以导出数据为多个工作表，参数传递多个url以及其对应sheetName

* 导出数组配置rownum，不同url请求的条数可以不一致

* php7将String定为关键字，将Org\Util\String改为Org\Util\StringHelper

* BaseBuilder添加setTopHtml方法

* BaseBuilder添加setTopHtml方法,添加截图说明

* update readme

* update readme

* update readme

* 配置管理添加配置名称唯一提示，将“配置标识“改为”配置名称“。

* 修改Queue获取JOB状态常量的方法；描述筛选字段应为description

* 修改Queue获取JOB状态常量的方法

* 获取listBuilder当前选中checkbox的值

* 获取listBuilder当前选中checkbox的值

* 地址选择器组件添加下拉框提示文字参数

* 添加后台js：根据API重置select2组件的值

* 添加后台js：根据API重置select2组件的值

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤