### PR TITLE
 修改FormType，ueditor组件forcecatchremote属性默认为true (#79)

### DIFF
--- a/docs/FormBuilder.md
+++ b/docs/FormBuilder.md
@@ -29,7 +29,10 @@ $url_prefix = U('/ip/q90', '', false, true) . '/' . U('/', '', false, true);
 ->addFormItem('content', 'ueditor', '正文内容','', '','','data-url="/Public/libs/ueditor/php/controller.php?oss=1&type=image"')
 ```
 
-复制外链文章时，强制要求抓取外链图片至本地，未抓取完会显示loadding图片(默认也会抓取外联图片，但如果未等全部抓取完就保存，此时图片还是外链)
+通过forcecatchremote属性设置是否强制要求抓取外链图片至本地，该属性默认为true。 
+```blade
+复制外链文章时，会抓取外链图片至本地。若该属性为true，则未抓取完会显示loadding图片且不能保存；若该属性为false，如果未等全部抓取完就保存，此时图片还是外链。
+```
 ```php
 //addFormItem第七个参数，设置data-forcecatchremote="true"
 ->addFormItem('desc', 'ueditor', '商家简介', '', '', '', 'data-forcecatchremote="true"')


### PR DESCRIPTION
* readme更新ueditor组件与RedisLock类注释

* top_menu的url使用U函数处理

* xh

* 扩展excel可以导出数据为多个工作表，参数传递多个url以及其对应sheetName

* 导出数组配置rownum，不同url请求的条数可以不一致

* php7将String定为关键字，将Org\Util\String改为Org\Util\StringHelper

* BaseBuilder添加setTopHtml方法

* BaseBuilder添加setTopHtml方法,添加截图说明

* update readme

* update readme

* update readme

* 配置管理添加配置名称唯一提示，将“配置标识“改为”配置名称“。

* 修改Queue获取JOB状态常量的方法；描述筛选字段应为description

* 修改Queue获取JOB状态常量的方法

* 获取listBuilder当前选中checkbox的值

* 获取listBuilder当前选中checkbox的值

* 地址选择器组件添加下拉框提示文字参数

* 添加后台js：根据API重置select2组件的值

* 添加后台js：根据API重置select2组件的值

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 扩展auth_ref_rule配置，可自定义不同用户类型的权限过滤

* 解决冲突

* xh

* 权限过滤:若查询数据表存在别名，自动处理auth_ref_key为“别名.字段名”

* 权限过滤:若查询数据表存在别名，自动处理auth_ref_key为“别名.字段名”

* showFileUrl添加默认图片参数

* showFileUrl添加默认图片参数

* 扩展imageproxy，支持参数file_id为url

* 扩展imageproxy，支持参数file_id为url

* 优化页码；ListBuilder添加setPageTemplate方法，可自定义页码模板

* 迁移权限过滤机制并添加字段权限过滤机制说明

* 完善文档

* 完善文档

* 完善文档

* 完善文档

* 完善文档

* 完善文档

* 完善文档

* 完善文档

* update readme

* update readme

* update readme

* update readme

* update readme

* update readme

* update readme

* update readme

* debug

* 队列worker使用多进程处理job且将计划任务改为使用子进程并行处理。

* 将\Common\Builder改为\Qscmf\Builder

* RedisLock 添加循环取锁

* 过滤权限字段应只有后台模块有效；更正column的拼写

* 取消队列手动加载任务类；修复重启队列方法queue前缀与不一致bug。

* xh

* 完善readme

* 完善readme

* 完善readme；点击search元素不跳转后重置为1。

* 优化listBuilder的search元素可触发beforeSearch事件，处理搜索前的动作

* 优化listBuilder的search元素可触发beforeSearch事件，处理搜索前的动作

* 优化redirect

* update readme.md

* update readme.md

* update readme.md

* 根据标识向html注入扩展包js/css链接

* update Extends.md

* update Extends.md

* update Extends.md

* update Extends.md

* update Extends.md

* update Extends.md

* update Extends.md

* update SubBuilder.md

* update SubBuilder.md

* update SubBuilder.md

* update SubBuilder.md

* 预防xss将Think.get改成I('get.')

* 将Think.get改成I('get.')

* FormBuilder支持设置是否展示按钮以及获取输出页面的内容。

* 补充文档

* 更新select2、district组件说明

* 更新select2、district组件说明

* ColumnType添加Num组件；ColumnType支持自定义组件编辑状态的html

* 添加如何开发列表列扩展说明

* 修改如何开发列表列字段扩展说明

* 修改ListBuilder说明

* ColumnType添加组件modal，点击弹出对话框功能

* xh

* xh

* xh

* 修复top button save类型提交列失败bug

* 修复top button save类型提交列失败bug

* 完善Resque.md

* 完善Resque.md

* 完善Resque.md

* 修改FormType，ueditor组件forcecatchremote属性默认为true